### PR TITLE
[BS] Update Expo SDK

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,31 +1,36 @@
 {
-    "expo": {
-        "name": "pokedex",
-        "scheme": "pokedex-app",
-        "slug": "pokedex",
-        "version": "1.0.0",
-        "orientation": "portrait",
-        "icon": "./assets/icon.png",
-        "userInterfaceStyle": "light",
-        "splash": {
-            "image": "./assets/splash.png",
-            "resizeMode": "contain",
-            "backgroundColor": "#ffffff"
-        },
-        "assetBundlePatterns": ["**/*"],
-        "ios": {
-            "supportsTablet": true
-        },
-        "android": {
-            "adaptiveIcon": {
-                "foregroundImage": "./assets/adaptive-icon.png",
-                "backgroundColor": "#ffffff"
-            }
-        },
-        "web": {
-            "bundler": "metro",
-            "favicon": "./assets/favicon.png"
-        },
-        "plugins": ["expo-router"]
-    }
+  "expo": {
+    "name": "pokedex",
+    "scheme": "pokedex-app",
+    "slug": "pokedex",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "userInterfaceStyle": "light",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#ffffff"
+      }
+    },
+    "web": {
+      "bundler": "metro",
+      "favicon": "./assets/favicon.png"
+    },
+    "plugins": [
+      "expo-router",
+      "expo-font"
+    ]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,20 @@
       "name": "pokedex",
       "version": "1.0.0",
       "dependencies": {
-        "@expo/metro-runtime": "~3.1.3",
-        "expo": "^50.0.18",
-        "expo-constants": "~15.4.6",
-        "expo-font": "^11.10.3",
-        "expo-linking": "~6.2.2",
-        "expo-router": "~3.4.10",
-        "expo-status-bar": "~1.11.1",
+        "@expo/metro-runtime": "~3.2.1",
+        "expo": "~51.0.6",
+        "expo-constants": "~16.0.1",
+        "expo-font": "~12.0.5",
+        "expo-linking": "~6.3.1",
+        "expo-router": "~3.5.14",
+        "expo-status-bar": "~1.12.1",
         "nativewind": "^2.0.11",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-native": "0.73.6",
+        "react-native": "0.74.1",
         "react-native-dotenv": "^3.4.11",
-        "react-native-safe-area-context": "4.8.2",
-        "react-native-screens": "~3.29.0",
+        "react-native-safe-area-context": "4.10.1",
+        "react-native-screens": "3.31.1",
         "react-native-web": "~0.19.6",
         "zustand": "^4.5.2"
       },
@@ -36,7 +36,7 @@
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5",
         "tailwindcss": "3.3.2",
-        "typescript": "^5.1.3"
+        "typescript": "~5.3.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -140,6 +140,7 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.15.tgz",
       "integrity": "sha512-QkBXwGgaoC2GtGZRoma6kv7Szfv06khvhFav67ZExau2RaXzy8MpHSMO2PNoP2XtmQphJQRHFfg77Bq731Yizw==",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.15"
       },
@@ -449,6 +450,7 @@
       "version": "7.24.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.5.tgz",
       "integrity": "sha512-LdXRi1wEMTrHVR4Zc9F8OewC3vdm5h4QB6L71zy6StmYeqGi1b3ttIO8UC+BfZKcH9jdr4aI249rBkm+3+YvHw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-plugin-utils": "^7.24.5"
@@ -464,6 +466,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.1.tgz",
       "integrity": "sha512-y4HqEnkelJIOQGd+3g1bTeKsA5c6qM7eOn7VggGVbBc0y8MLSKHacwcIE2PplNlQSj0PqS9rrXL/nkPVK+kUNg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -478,6 +481,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.24.1.tgz",
       "integrity": "sha512-Hj791Ii4ci8HqnaKHAlLNs+zaLXb0EzSDhiAWp5VNlyvCNymYfacs64pxTxbH1znW/NcArSmwpmG9IKE/TUVVQ==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
@@ -494,6 +498,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.24.1.tgz",
       "integrity": "sha512-m9m/fXsXLiHfwdgydIFnpk+7jlVbnvlK5B2EKiPdLUb6WX654ZaaEWJUjk8TftRbZpK0XibovlLWX4KIZhV6jw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-plugin-utils": "^7.24.0"
@@ -575,7 +580,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.20.7.tgz",
       "integrity": "sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==",
       "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
@@ -675,6 +679,7 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       },
@@ -697,6 +702,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
       },
@@ -708,6 +714,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -786,6 +793,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.1.tgz",
       "integrity": "sha512-IuwnI5XnuF189t91XbxmXeCDz3qs6iDRO7GJ++wcfgeXNs/8FmIlKcpDSXNVyuLQxlwvskmI3Ct73wUODkJBlQ==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -800,6 +808,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.1.tgz",
       "integrity": "sha512-zhQTMH0X2nVLnb04tz+s7AMuasX8U0FnpE+nHTOhSOINjWMnopoZTxtIKsd45n4GQ/HIZLyfIpoul8e2m0DnRA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -814,6 +823,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -825,6 +835,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -930,6 +941,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -958,6 +970,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
       "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -987,6 +1000,7 @@
       "version": "7.24.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.3.tgz",
       "integrity": "sha512-Qe26CMYVjpQxJ8zxM1340JFNjZaF+ISWpr1Kt/jGo+ZTUzKkfw/pphEWbRCb+lmSM6k/TOgfYLvmbHkUQ0asIg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-plugin-utils": "^7.24.0",
@@ -1020,6 +1034,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.1.tgz",
       "integrity": "sha512-TWWC18OShZutrv9C6mye1xwtam+uNi2bnTOCBUd5sZxyHOiWbU6ztSROofIMrK84uweEZC219POICK/sTYwfgg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -1048,6 +1063,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.1.tgz",
       "integrity": "sha512-OMLCXi0NqvJfORTaPQBwqLXHhb93wkBKZ4aNwMl6WtehO7ar+cmp+89iPEQPqxAnxsOKTaMcs3POz3rKayJ72g==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.24.1",
         "@babel/helper-plugin-utils": "^7.24.0"
@@ -1063,6 +1079,7 @@
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.4.tgz",
       "integrity": "sha512-B8q7Pz870Hz/q9UgP8InNpY01CSLDSCyqX7zcRuv3FcPl87A2G17lASroHWaCtbdIcbYzOZ7kWmXFKbijMSmFg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.24.4",
         "@babel/helper-plugin-utils": "^7.24.0",
@@ -1129,6 +1146,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.24.1.tgz",
       "integrity": "sha512-p7uUxgSoZwZ2lPNMzUkqCts3xlp8n+o05ikjy7gbtFJSt9gdU88jAmtfmOxHM14noQXBxfgzf2yRWECiNVhTCw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.24.0"
@@ -1144,6 +1162,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.24.1.tgz",
       "integrity": "sha512-msyzuUnvsjsaSaocV6L7ErfNsa5nDWL1XKNnDePLgmz+WdU4w/J8+AxBMrWfi9m4IxfL5sZQKUPQKDQeeAT6lA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -1158,6 +1177,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.24.1.tgz",
       "integrity": "sha512-av2gdSTyXcJVdI+8aFZsCAtR29xJt0S5tas+Ef8NvBNmD1a+N/3ecMLeMBgfcK+xzsjdLDT6oHt+DFPyeqUbDA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3"
@@ -1173,6 +1193,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.24.1.tgz",
       "integrity": "sha512-U1yX13dVBSwS23DEAqU+Z/PkwE9/m7QQy8Y9/+Tdb8UWYaGNDYwTLi19wqIAiROr8sXVum9A/rtiH5H0boUcTw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.24.0"
@@ -1218,6 +1239,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.1.tgz",
       "integrity": "sha512-OxBdcnF04bpdQdR3i4giHZNZQn7cm8RQKcSwA17wAAqEELo1ZOwp5FFgeptWUQXFyT9kwHo10aqqauYkRZPCAg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
@@ -1249,6 +1271,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.24.1.tgz",
       "integrity": "sha512-U7RMFmRvoasscrIFy5xA4gIp8iWnWubnKkKuUGJjsuOH7GfbMkB+XZzeslx2kLdEGdOJDamEmCqOks6e8nv8DQ==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0",
         "@babel/plugin-syntax-json-strings": "^7.8.3"
@@ -1278,6 +1301,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.24.1.tgz",
       "integrity": "sha512-OhN6J4Bpz+hIBqItTeWJujDOfNP+unqv/NJgyhlpSqgBTPm37KkMmZV6SYcOj+pnDbdcl1qRGV/ZiIjX9Iy34w==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
@@ -1293,6 +1317,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.1.tgz",
       "integrity": "sha512-4ojai0KysTWXzHseJKa1XPNXKRbuUrhkOPY4rEGeR+7ChlJVKxFa3H3Bz+7tWaGKgJAXUWKOGmltN+u9B3+CVg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -1307,6 +1332,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.24.1.tgz",
       "integrity": "sha512-lAxNHi4HVtjnHd5Rxg3D5t99Xm6H7b04hUS7EHIXcUl2EV4yl1gWdqZrNzXnSrHveL9qMdbODlLF55mvgjAfaQ==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.23.3",
         "@babel/helper-plugin-utils": "^7.24.0"
@@ -1338,6 +1364,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.24.1.tgz",
       "integrity": "sha512-mqQ3Zh9vFO1Tpmlt8QPnbwGHzNz3lpNEMxQb1kAemn/erstyqw1r9KeOlOfo3y6xAnFEcOv2tSyrXfmMk+/YZA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-module-transforms": "^7.23.3",
@@ -1355,6 +1382,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.24.1.tgz",
       "integrity": "sha512-tuA3lpPj+5ITfcCluy6nWonSL7RvaG0AOTeAuvXqEKS34lnLzXpDb0dcP6K8jD0zWZFNDVly90AGFJPnm4fOYg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.23.3",
         "@babel/helper-plugin-utils": "^7.24.0"
@@ -1385,6 +1413,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.24.1.tgz",
       "integrity": "sha512-/rurytBM34hYy0HKZQyA0nHbQgQNFm4Q/BOc9Hflxi2X3twRof7NaE5W46j4kQitm7SvACVRXsa6N/tSZxvPug==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -1399,6 +1428,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.1.tgz",
       "integrity": "sha512-iQ+caew8wRrhCikO5DrUYx0mrmdhkaELgFa+7baMcVuhxIkN7oxt06CZ51D65ugIb1UWRQ8oQe+HXAVM6qHFjw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
@@ -1414,6 +1444,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.24.1.tgz",
       "integrity": "sha512-7GAsGlK4cNL2OExJH1DzmDeKnRv/LXq0eLUSvudrehVA5Rgg4bIrqEUW29FbKMBRT0ztSqisv7kjP+XIC4ZMNw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
@@ -1446,6 +1477,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.1.tgz",
       "integrity": "sha512-oKJqR3TeI5hSLRxudMjFQ9re9fBVUU0GICqM3J1mi8MqlhVr6hC/ZN4ttAyMuQR6EZZIY6h/exe5swqGNNIkWQ==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0",
         "@babel/helper-replace-supers": "^7.24.1"
@@ -1461,6 +1493,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.24.1.tgz",
       "integrity": "sha512-oBTH7oURV4Y+3EUrf6cWn1OHio3qG/PVwO5J03iSJmBg6m2EhKjkAu/xuaXaYwWW9miYtvbWv4LNf0AmR43LUA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
@@ -1476,6 +1509,7 @@
       "version": "7.24.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.5.tgz",
       "integrity": "sha512-xWCkmwKT+ihmA6l7SSTpk8e4qQl/274iNbSKRRS8mpqFR32ksy36+a+LWY8OXCCEefF8WFlnOHVsaDI2231wBg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
@@ -1538,6 +1572,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.1.tgz",
       "integrity": "sha512-LetvD7CrHmEx0G442gOomRr66d7q8HzzGGr4PMHGr+5YIm6++Yke+jxj246rpvsbyhJwCLxcTn6zW1P1BSenqA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -1641,6 +1676,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.24.1.tgz",
       "integrity": "sha512-sJwZBCzIBE4t+5Q4IGLaaun5ExVMRY0lYwos/jNecjMrVCygCdph3IKv0tkP5Fc87e/1+bebAmEAGBfnRD+cnw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0",
         "regenerator-transform": "^0.15.2"
@@ -1656,6 +1692,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.24.1.tgz",
       "integrity": "sha512-JAclqStUfIwKN15HrsQADFgeZt+wexNQ0uLhuqvqAUFoqPMjEcFCYZBhq0LUdz6dZK/mD+rErhW71fbx8RYElg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -1732,6 +1769,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.1.tgz",
       "integrity": "sha512-WRkhROsNzriarqECASCNu/nojeXCDTE/F2HmRgOzi7NGvyfYGq1NEjKBK3ckLfRgGc6/lPAqP0vDOSw3YtG34g==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -1746,6 +1784,7 @@
       "version": "7.24.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.5.tgz",
       "integrity": "sha512-UTGnhYVZtTAjdwOTzT+sCyXmTn8AhaxOS/MjG9REclZ6ULHWF9KoCZur0HSGU7hk8PdBFKKbYe6+gqdXWz84Jg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.5"
       },
@@ -1777,6 +1816,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.24.1.tgz",
       "integrity": "sha512-RlkVIcWT4TLI96zM660S877E7beKlQw7Ig+wqkKBiWfj0zH5Q4h50q6er4wzZKRNSYpfo6ILJ+hrJAGSX2qcNw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -1791,6 +1831,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.24.1.tgz",
       "integrity": "sha512-Ss4VvlfYV5huWApFsF8/Sq0oXnGO+jB+rijFEFugTd3cwSObUSnUi88djgR5528Csl0uKlrI331kRqe56Ov2Ng==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.24.0"
@@ -1821,6 +1862,7 @@
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.1.tgz",
       "integrity": "sha512-fqj4WuzzS+ukpgerpAoOnMfQXwUHFxXUZUE84oL2Kao2N8uSlvcpnAidKASgsNgzZHBsHWvcm8s9FPWUhAb8fA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.24.0"
@@ -1836,6 +1878,7 @@
       "version": "7.24.5",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.5.tgz",
       "integrity": "sha512-UGK2ifKtcC8i5AI4cH+sbLLuLc2ktYSFJgBAXorKAsHUZmrQ1q6aQ6i3BvU24wWs2AAKqQB6kq3N9V9Gw1HiMQ==",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.24.4",
         "@babel/helper-compilation-targets": "^7.23.6",
@@ -1946,6 +1989,7 @@
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
       "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/types": "^7.4.4",
@@ -2171,27 +2215,27 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.17.11.tgz",
-      "integrity": "sha512-EyAL/x9yyN9nA0iiZC0XZLvSBbKtl1GT38HNgrPmTb0KEzVlpbSJoWfw2vn9g/NnWPS1wMKRU2I5U42d/tvqvg==",
+      "version": "0.18.12",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.18.12.tgz",
+      "integrity": "sha512-rsN8DO3aU3sWFfl1mlIcLOFJUAYxG1U0XalEwQaT7ZkVT+9G70PqEjuraCm/vKc4aOnJ5wsecaHzQOvZywmGmg==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/code-signing-certificates": "0.0.5",
-        "@expo/config": "~8.5.0",
-        "@expo/config-plugins": "~7.9.0",
+        "@expo/config": "~9.0.0-beta.0",
+        "@expo/config-plugins": "~8.0.0-beta.0",
         "@expo/devcert": "^1.0.0",
-        "@expo/env": "~0.2.2",
-        "@expo/image-utils": "^0.4.0",
-        "@expo/json-file": "^8.2.37",
-        "@expo/metro-config": "~0.17.0",
+        "@expo/env": "~0.3.0",
+        "@expo/image-utils": "^0.5.0",
+        "@expo/json-file": "^8.3.0",
+        "@expo/metro-config": "~0.18.0",
         "@expo/osascript": "^2.0.31",
-        "@expo/package-manager": "^1.1.1",
+        "@expo/package-manager": "^1.5.0",
         "@expo/plist": "^0.1.0",
-        "@expo/prebuild-config": "6.8.1",
+        "@expo/prebuild-config": "7.0.3",
         "@expo/rudder-sdk-node": "1.1.1",
-        "@expo/spawn-async": "1.5.0",
+        "@expo/spawn-async": "^1.7.2",
         "@expo/xcpretty": "^4.3.0",
-        "@react-native/dev-middleware": "^0.73.6",
+        "@react-native/dev-middleware": "~0.74.75",
         "@urql/core": "2.3.6",
         "@urql/exchange-retry": "0.3.0",
         "accepts": "^1.3.8",
@@ -2204,6 +2248,7 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "env-editor": "^0.4.1",
+        "fast-glob": "^3.3.2",
         "find-yarn-workspace-root": "~2.0.0",
         "form-data": "^3.0.1",
         "freeport-async": "2.0.0",
@@ -2221,7 +2266,6 @@
         "lodash.debounce": "^4.0.8",
         "md5hex": "^1.0.0",
         "minimatch": "^3.0.4",
-        "minipass": "3.3.6",
         "node-fetch": "^2.6.7",
         "node-forge": "^1.3.1",
         "npm-package-arg": "^7.0.0",
@@ -2237,7 +2281,7 @@
         "resolve": "^1.22.2",
         "resolve-from": "^5.0.0",
         "resolve.exports": "^2.0.2",
-        "semver": "^7.5.3",
+        "semver": "^7.6.0",
         "send": "^0.18.0",
         "slugify": "^1.3.4",
         "source-map-support": "~0.5.21",
@@ -2361,41 +2405,39 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-8.5.6.tgz",
-      "integrity": "sha512-wF5awSg6MNn1cb1lIgjnhOn5ov2TEUTnkAVCsOl0QqDwcP+YIerteSFwjn9V52UZvg58L+LKxpCuGbw5IHavbg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-9.0.1.tgz",
+      "integrity": "sha512-0tjaXBstTbXmD4z+UMFBkh2SZFwilizSQhW6DlaTMnPG5ezuw93zSFEWAuEC3YzkpVtNQTmYzxAYjxwh6seOGg==",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~7.9.0",
-        "@expo/config-types": "^50.0.0",
-        "@expo/json-file": "^8.2.37",
+        "@expo/config-plugins": "~8.0.0-beta.0",
+        "@expo/config-types": "^51.0.0-unreleased",
+        "@expo/json-file": "^8.3.0",
         "getenv": "^1.0.0",
         "glob": "7.1.6",
         "require-from-string": "^2.0.2",
         "resolve-from": "^5.0.0",
-        "semver": "7.5.3",
+        "semver": "^7.6.0",
         "slugify": "^1.3.4",
         "sucrase": "3.34.0"
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.9.2.tgz",
-      "integrity": "sha512-sRU/OAp7kJxrCUiCTUZqvPMKPdiN1oTmNfnbkG4oPdfWQTpid3jyCH7ZxJEN5SI6jrY/ZsK5B/JPgjDUhuWLBQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-8.0.4.tgz",
+      "integrity": "sha512-Hi+xuyNWE2LT4LVbGttHJgl9brnsdWAhEB42gWKb5+8ae86Nr/KwUBQJsJppirBYTeLjj5ZlY0glYnAkDa2jqw==",
       "dependencies": {
-        "@expo/config-types": "^50.0.0-alpha.1",
-        "@expo/fingerprint": "^0.6.0",
+        "@expo/config-types": "^51.0.0-unreleased",
         "@expo/json-file": "~8.3.0",
         "@expo/plist": "^0.1.0",
         "@expo/sdk-runtime-versions": "^1.0.0",
-        "@react-native/normalize-color": "^2.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.1",
         "find-up": "~5.0.0",
         "getenv": "^1.0.0",
         "glob": "7.1.6",
         "resolve-from": "^5.0.0",
-        "semver": "^7.5.3",
+        "semver": "^7.5.4",
         "slash": "^3.0.0",
         "slugify": "^1.6.6",
         "xcode": "^3.0.1",
@@ -2474,24 +2516,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/@expo/config-plugins/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/config-plugins/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2510,15 +2538,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/@expo/config-plugins/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/@expo/config-types": {
-      "version": "50.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-50.0.1.tgz",
-      "integrity": "sha512-EZHMgzkWRB9SMHO1e9m8s+OMahf92XYTnsCFjxhSfcDrcEoSdFPyJWDJVloHZPMGhxns7Fi2+A+bEVN/hD4NKA=="
+      "version": "51.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-51.0.0.tgz",
+      "integrity": "sha512-acn03/u8mQvBhdTQtA7CNhevMltUhbSrpI01FYBJwpVntufkU++ncQujWKlgY/OwIajcfygk1AY4xcNZ5ImkRA=="
     },
     "node_modules/@expo/config/node_modules/@babel/code-frame": {
       "version": "7.10.4",
@@ -2547,35 +2570,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@expo/config/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/config/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@expo/config/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@expo/devcert": {
       "version": "1.1.0",
@@ -2606,9 +2610,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-0.2.3.tgz",
-      "integrity": "sha512-a+uJ/e6MAVxPVVN/HbXU5qxzdqrqDwNQYxCfxtAufgmd5VZj54e5f3TJA3LEEUW3pTSZR8xK0H0EtVN297AZnw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-0.3.0.tgz",
+      "integrity": "sha512-OtB9XVHWaXidLbHvrVDeeXa09yvTl3+IQN884sO6PhIi2/StXfgSH/9zC7IvzrDB8kW3EBJ1PPLuCUJ2hxAT7Q==",
       "dependencies": {
         "chalk": "^4.0.0",
         "debug": "^4.3.4",
@@ -2681,93 +2685,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/@expo/fingerprint": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.6.1.tgz",
-      "integrity": "sha512-ggLn6unI6qowlA1FihdQwPpLn16VJulYkvYAEL50gaqVahfNEglRQMSH2giZzjD0d6xq2/EQuUdFyHaJfyJwOQ==",
-      "dependencies": {
-        "@expo/spawn-async": "^1.5.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.4",
-        "find-up": "^5.0.0",
-        "minimatch": "^3.0.4",
-        "p-limit": "^3.1.0",
-        "resolve-from": "^5.0.0"
-      },
-      "bin": {
-        "fingerprint": "bin/cli.js"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@expo/fingerprint/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@expo/image-utils": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.4.2.tgz",
-      "integrity": "sha512-CxP+1QXgRXsNnmv2FAUA2RWwK6kNBFg4QEmVXn2K9iLoEAI+i+1IQXcUgc+J7nTJl9pO7FIu2gIiEYGYffjLWQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.5.1.tgz",
+      "integrity": "sha512-U/GsFfFox88lXULmFJ9Shfl2aQGcwoKPF7fawSCLixIKtMCpsI+1r0h+5i0nQnmt9tHuzXZDL8+Dg1z6OhkI9A==",
       "dependencies": {
-        "@expo/spawn-async": "1.5.0",
+        "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "fs-extra": "9.0.0",
         "getenv": "^1.0.0",
@@ -2775,7 +2698,7 @@
         "node-fetch": "^2.6.0",
         "parse-png": "^2.1.0",
         "resolve-from": "^5.0.0",
-        "semver": "7.3.2",
+        "semver": "^7.6.0",
         "tempy": "0.3.0"
       }
     },
@@ -2874,9 +2797,9 @@
       }
     },
     "node_modules/@expo/image-utils/node_modules/semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2962,19 +2885,18 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.17.7.tgz",
-      "integrity": "sha512-3vAdinAjMeRwdhGWWLX6PziZdAPvnyJ6KVYqnJErHHqH0cA6dgAENT3Vq6PEM1H2HgczKr2d5yG9AMgwy848ow==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.18.3.tgz",
+      "integrity": "sha512-E4iW+VT/xHPPv+t68dViOsW7egtGIr+sRElcym0iGpC4goLz9WBux/xGzWgxvgvvHEWa21uSZQPM0jWla0OZXg==",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
         "@babel/parser": "^7.20.0",
         "@babel/types": "^7.20.0",
-        "@expo/config": "~8.5.0",
-        "@expo/env": "~0.2.2",
+        "@expo/config": "~9.0.0-beta.0",
+        "@expo/env": "~0.3.0",
         "@expo/json-file": "~8.3.0",
         "@expo/spawn-async": "^1.7.2",
-        "babel-preset-fbjs": "^3.4.0",
         "chalk": "^4.1.0",
         "debug": "^4.3.2",
         "find-yarn-workspace-root": "~2.0.0",
@@ -2984,22 +2906,7 @@
         "jsc-safe-url": "^0.2.4",
         "lightningcss": "~1.19.0",
         "postcss": "~8.4.32",
-        "resolve-from": "^5.0.0",
-        "sucrase": "3.34.0"
-      },
-      "peerDependencies": {
-        "@react-native/babel-preset": "*"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/@expo/spawn-async": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
-      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=12"
+        "resolve-from": "^5.0.0"
       }
     },
     "node_modules/@expo/metro-config/node_modules/ansi-styles": {
@@ -3100,9 +3007,9 @@
       }
     },
     "node_modules/@expo/metro-runtime": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-3.1.3.tgz",
-      "integrity": "sha512-u1CaQJJlSgvxBB5NJ6YMVvSDTTRzjT71dHpEBnKPZhpFv5ebVry52FZ2sEeEEA6mHG5zGxWXmHImW3hNKHh8EA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-3.2.1.tgz",
+      "integrity": "sha512-L7xNo5SmK+rcuXDm/+VBBImpA7FZsVB+m/rNr3fNl5or+1+yrZe99ViF7LZ8DOoVqAqcb4aCAXvGrP2JNYo1/Q==",
       "peerDependencies": {
         "react-native": "*"
       }
@@ -3114,17 +3021,6 @@
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
         "exec-async": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@expo/osascript/node_modules/@expo/spawn-async": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
-      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3"
       },
       "engines": {
         "node": ">=12"
@@ -3147,17 +3043,6 @@
         "ora": "^3.4.0",
         "split": "^1.0.1",
         "sudo-prompt": "9.1.1"
-      }
-    },
-    "node_modules/@expo/package-manager/node_modules/@expo/spawn-async": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
-      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@expo/package-manager/node_modules/ansi-styles": {
@@ -3260,19 +3145,20 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-6.8.1.tgz",
-      "integrity": "sha512-ptK9e0dcj1eYlAWV+fG+QkuAWcLAT1AmtEbj++tn7ZjEj8+LkXRM73LCOEGaF0Er8i8ZWNnaVsgGW4vjgP5ZsA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-7.0.3.tgz",
+      "integrity": "sha512-Kvxy/oQzkxwXLvAmwb+ygxuRn4xUUN2+mVJj3KDe4bRVCNyDPs7wlgdokF3twnWjzRZssUzseMkhp+yHPjAEhA==",
       "dependencies": {
-        "@expo/config": "~8.5.0",
-        "@expo/config-plugins": "~7.9.0",
-        "@expo/config-types": "^50.0.0-alpha.1",
-        "@expo/image-utils": "^0.4.0",
-        "@expo/json-file": "^8.2.37",
+        "@expo/config": "~9.0.0-beta.0",
+        "@expo/config-plugins": "~8.0.0-beta.0",
+        "@expo/config-types": "^51.0.0-unreleased",
+        "@expo/image-utils": "^0.5.0",
+        "@expo/json-file": "^8.3.0",
+        "@react-native/normalize-colors": "~0.74.83",
         "debug": "^4.3.1",
         "fs-extra": "^9.0.0",
         "resolve-from": "^5.0.0",
-        "semver": "7.5.3",
+        "semver": "^7.6.0",
         "xml2js": "0.6.0"
       },
       "peerDependencies": {
@@ -3304,24 +3190,10 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/@expo/prebuild-config/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/prebuild-config/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3336,11 +3208,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@expo/rudder-sdk-node": {
       "version": "1.1.1",
@@ -3365,86 +3232,25 @@
       "integrity": "sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ=="
     },
     "node_modules/@expo/server": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@expo/server/-/server-0.3.1.tgz",
-      "integrity": "sha512-cCKyVA2IR9J4hDFPXzj3L08+Ngd/7z2F+JtdW0NLy03qShXBI5NSEEcaiHtjrgsLXPDe9PBw5Xgsfmxuduyggg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo/server/-/server-0.4.2.tgz",
+      "integrity": "sha512-HuXbzXTJh1/JG8FRuxcBqTNEuiriMhNhvh68CNCUXMR/s1f29DmZPBq+/IbG8yk+TkXvKIHjmUGAqqz/ddfyvA==",
       "dependencies": {
-        "@remix-run/node": "^1.19.3",
+        "@remix-run/node": "^2.7.2",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.4",
         "source-map-support": "~0.5.21"
       }
     },
     "node_modules/@expo/spawn-async": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.5.0.tgz",
-      "integrity": "sha512-LB7jWkqrHo+5fJHNrLAFdimuSXQ2MQ4lA7SQW5bf/HbsXuV2VrT/jN/M8f/KoWt0uJMGN4k/j7Opx4AvOOxSew==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
+      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
       "dependencies": {
-        "cross-spawn": "^6.0.5"
+        "cross-spawn": "^7.0.3"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
+        "node": ">=12"
       }
     },
     "node_modules/@expo/vector-icons": {
@@ -3918,19 +3724,18 @@
       }
     },
     "node_modules/@react-native-community/cli": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-12.3.6.tgz",
-      "integrity": "sha512-647OSi6xBb8FbwFqX9zsJxOzu685AWtrOUWHfOkbKD+5LOpGORw+GQo0F9rWZnB68rLQyfKUZWJeaD00pGv5fw==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-13.6.6.tgz",
+      "integrity": "sha512-IqclB7VQ84ye8Fcs89HOpOscY4284VZg2pojHNl8H0Lzd4DadXJWQoxC7zWm8v2f8eyeX2kdhxp2ETD5tceIgA==",
       "dependencies": {
-        "@react-native-community/cli-clean": "12.3.6",
-        "@react-native-community/cli-config": "12.3.6",
-        "@react-native-community/cli-debugger-ui": "12.3.6",
-        "@react-native-community/cli-doctor": "12.3.6",
-        "@react-native-community/cli-hermes": "12.3.6",
-        "@react-native-community/cli-plugin-metro": "12.3.6",
-        "@react-native-community/cli-server-api": "12.3.6",
-        "@react-native-community/cli-tools": "12.3.6",
-        "@react-native-community/cli-types": "12.3.6",
+        "@react-native-community/cli-clean": "13.6.6",
+        "@react-native-community/cli-config": "13.6.6",
+        "@react-native-community/cli-debugger-ui": "13.6.6",
+        "@react-native-community/cli-doctor": "13.6.6",
+        "@react-native-community/cli-hermes": "13.6.6",
+        "@react-native-community/cli-server-api": "13.6.6",
+        "@react-native-community/cli-tools": "13.6.6",
+        "@react-native-community/cli-types": "13.6.6",
         "chalk": "^4.1.2",
         "commander": "^9.4.1",
         "deepmerge": "^4.3.0",
@@ -3949,13 +3754,14 @@
       }
     },
     "node_modules/@react-native-community/cli-clean": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-12.3.6.tgz",
-      "integrity": "sha512-gUU29ep8xM0BbnZjwz9MyID74KKwutq9x5iv4BCr2im6nly4UMf1B1D+V225wR7VcDGzbgWjaezsJShLLhC5ig==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-13.6.6.tgz",
+      "integrity": "sha512-cBwJTwl0NyeA4nyMxbhkWZhxtILYkbU3TW3k8AXLg+iGphe0zikYMGB3T+haTvTc6alTyEFwPbimk9bGIqkjAQ==",
       "dependencies": {
-        "@react-native-community/cli-tools": "12.3.6",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
-        "execa": "^5.0.0"
+        "execa": "^5.0.0",
+        "fast-glob": "^3.3.2"
       }
     },
     "node_modules/@react-native-community/cli-clean/node_modules/ansi-styles": {
@@ -4078,15 +3884,15 @@
       }
     },
     "node_modules/@react-native-community/cli-config": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-12.3.6.tgz",
-      "integrity": "sha512-JGWSYQ9EAK6m2v0abXwFLEfsqJ1zkhzZ4CV261QZF9MoUNB6h57a274h1MLQR9mG6Tsh38wBUuNfEPUvS1vYew==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-13.6.6.tgz",
+      "integrity": "sha512-mbG425zCKr8JZhv/j11382arezwS/70juWMsn8j2lmrGTrP1cUdW0MF15CCIFtJsqyK3Qs+FTmqttRpq81QfSg==",
       "dependencies": {
-        "@react-native-community/cli-tools": "12.3.6",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
         "cosmiconfig": "^5.1.0",
         "deepmerge": "^4.3.0",
-        "glob": "^7.1.3",
+        "fast-glob": "^3.3.2",
         "joi": "^17.2.1"
       }
     },
@@ -4155,22 +3961,23 @@
       }
     },
     "node_modules/@react-native-community/cli-debugger-ui": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-12.3.6.tgz",
-      "integrity": "sha512-SjUKKsx5FmcK9G6Pb6UBFT0s9JexVStK5WInmANw75Hm7YokVvHEgtprQDz2Uvy5znX5g2ujzrkIU//T15KQzA==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-13.6.6.tgz",
+      "integrity": "sha512-Vv9u6eS4vKSDAvdhA0OiQHoA7y39fiPIgJ6biT32tN4avHDtxlc6TWZGiqv7g98SBvDWvoVAmdPLcRf3kU+c8g==",
       "dependencies": {
         "serve-static": "^1.13.1"
       }
     },
     "node_modules/@react-native-community/cli-doctor": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-12.3.6.tgz",
-      "integrity": "sha512-fvBDv2lTthfw4WOQKkdTop2PlE9GtfrlNnpjB818MhcdEnPjfQw5YaTUcnNEGsvGomdCs1MVRMgYXXwPSN6OvQ==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-13.6.6.tgz",
+      "integrity": "sha512-TWZb5g6EmQe2Ua2TEWNmyaEayvlWH4GmdD9ZC+p8EpKFpB1NpDGMK6sXbpb42TDvwZg5s4TDRplK0PBEA/SVDg==",
       "dependencies": {
-        "@react-native-community/cli-config": "12.3.6",
-        "@react-native-community/cli-platform-android": "12.3.6",
-        "@react-native-community/cli-platform-ios": "12.3.6",
-        "@react-native-community/cli-tools": "12.3.6",
+        "@react-native-community/cli-config": "13.6.6",
+        "@react-native-community/cli-platform-android": "13.6.6",
+        "@react-native-community/cli-platform-apple": "13.6.6",
+        "@react-native-community/cli-platform-ios": "13.6.6",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
         "command-exists": "^1.2.8",
         "deepmerge": "^4.3.0",
@@ -4308,17 +4115,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@react-native-community/cli-doctor/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@react-native-community/cli-doctor/node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -4376,12 +4172,9 @@
       }
     },
     "node_modules/@react-native-community/cli-doctor/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4419,18 +4212,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-doctor/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/@react-native-community/cli-hermes": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-12.3.6.tgz",
-      "integrity": "sha512-sNGwfOCl8OAIjWCkwuLpP8NZbuO0dhDI/2W7NeOGDzIBsf4/c4MptTrULWtGIH9okVPLSPX0NnRyGQ+mSwWyuQ==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-13.6.6.tgz",
+      "integrity": "sha512-La5Ie+NGaRl3klei6WxKoOxmCUSGGxpOk6vU5pEGf0/O7ky+Ay0io+zXYUZqlNMi/cGpO7ZUijakBYOB/uyuFg==",
       "dependencies": {
-        "@react-native-community/cli-platform-android": "12.3.6",
-        "@react-native-community/cli-tools": "12.3.6",
+        "@react-native-community/cli-platform-android": "13.6.6",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6"
       }
@@ -4500,15 +4288,15 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-12.3.6.tgz",
-      "integrity": "sha512-DeDDAB8lHpuGIAPXeeD9Qu2+/wDTFPo99c8uSW49L0hkmZJixzvvvffbGQAYk32H0TmaI7rzvzH+qzu7z3891g==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-13.6.6.tgz",
+      "integrity": "sha512-/tMwkBeNxh84syiSwNlYtmUz/Ppc+HfKtdopL/5RB+fd3SV1/5/NPNjMlyLNgFKnpxvKCInQ7dnl6jGHJjeHjg==",
       "dependencies": {
-        "@react-native-community/cli-tools": "12.3.6",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
+        "fast-glob": "^3.3.2",
         "fast-xml-parser": "^4.2.4",
-        "glob": "^7.1.3",
         "logkitty": "^0.7.1"
       }
     },
@@ -4631,20 +4419,20 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-12.3.6.tgz",
-      "integrity": "sha512-3eZ0jMCkKUO58wzPWlvAPRqezVKm9EPZyaPyHbRPWU8qw7JqkvnRlWIaYDGpjCJgVW4k2hKsEursLtYKb188tg==",
+    "node_modules/@react-native-community/cli-platform-apple": {
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-apple/-/cli-platform-apple-13.6.6.tgz",
+      "integrity": "sha512-bOmSSwoqNNT3AmCRZXEMYKz1Jf1l2F86Nhs7qBcXdY/sGiJ+Flng564LOqvdAlVLTbkgz47KjNKCS2pP4Jg0Mg==",
       "dependencies": {
-        "@react-native-community/cli-tools": "12.3.6",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
+        "fast-glob": "^3.3.2",
         "fast-xml-parser": "^4.0.12",
-        "glob": "^7.1.3",
         "ora": "^5.4.1"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/ansi-styles": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
@@ -4658,7 +4446,7 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/chalk": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
@@ -4673,7 +4461,7 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/cli-cursor": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
@@ -4684,7 +4472,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/color-convert": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
@@ -4695,12 +4483,12 @@
         "node": ">=7.0.0"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/color-name": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/execa": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
@@ -4722,7 +4510,7 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/get-stream": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
@@ -4733,7 +4521,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/has-flag": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
@@ -4741,7 +4529,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/is-stream": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
@@ -4752,7 +4540,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/log-symbols": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
@@ -4767,7 +4555,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/npm-run-path": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
@@ -4778,7 +4566,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/ora": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/ora": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
@@ -4800,7 +4588,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/restore-cursor": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
@@ -4812,7 +4600,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/supports-color": {
+    "node_modules/@react-native-community/cli-platform-apple/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -4823,54 +4611,46 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-plugin-metro": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-12.3.6.tgz",
-      "integrity": "sha512-3jxSBQt4fkS+KtHCPSyB5auIT+KKIrPCv9Dk14FbvOaEh9erUWEm/5PZWmtboW1z7CYeNbFMeXm9fM2xwtVOpg=="
+    "node_modules/@react-native-community/cli-platform-ios": {
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-13.6.6.tgz",
+      "integrity": "sha512-vjDnRwhlSN5ryqKTas6/DPkxuouuyFBAqAROH4FR1cspTbn6v78JTZKDmtQy9JMMo7N5vZj1kASU5vbFep9IOQ==",
+      "dependencies": {
+        "@react-native-community/cli-platform-apple": "13.6.6"
+      }
     },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-12.3.6.tgz",
-      "integrity": "sha512-80NIMzo8b2W+PL0Jd7NjiJW9mgaT8Y8wsIT/lh6mAvYH7mK0ecDJUYUTAAv79Tbo1iCGPAr3T295DlVtS8s4yQ==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-13.6.6.tgz",
+      "integrity": "sha512-ZtCXxoFlM7oDv3iZ3wsrT3SamhtUJuIkX2WePLPlN5bcbq7zimbPm2lHyicNJtpcGQ5ymsgpUWPCNZsWQhXBqQ==",
       "dependencies": {
-        "@react-native-community/cli-debugger-ui": "12.3.6",
-        "@react-native-community/cli-tools": "12.3.6",
+        "@react-native-community/cli-debugger-ui": "13.6.6",
+        "@react-native-community/cli-tools": "13.6.6",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.1",
         "nocache": "^3.0.1",
         "pretty-format": "^26.6.2",
         "serve-static": "^1.13.1",
-        "ws": "^7.5.1"
+        "ws": "^6.2.2"
       }
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-12.3.6.tgz",
-      "integrity": "sha512-FPEvZn19UTMMXUp/piwKZSh8cMEfO8G3KDtOwo53O347GTcwNrKjgZGtLSPELBX2gr+YlzEft3CoRv2Qmo83fQ==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-13.6.6.tgz",
+      "integrity": "sha512-ptOnn4AJczY5njvbdK91k4hcYazDnGtEPrqIwEI+k/CTBHNdb27Rsm2OZ7ye6f7otLBqF8gj/hK6QzJs8CEMgw==",
       "dependencies": {
         "appdirsjs": "^1.2.4",
         "chalk": "^4.1.2",
+        "execa": "^5.0.0",
         "find-up": "^5.0.0",
         "mime": "^2.4.1",
         "node-fetch": "^2.6.0",
@@ -4937,12 +4717,56 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/@react-native-community/cli-tools/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@react-native-community/cli-tools/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@react-native-community/cli-tools/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli-tools/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@react-native-community/cli-tools/node_modules/is-wsl": {
@@ -4968,15 +4792,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@react-native-community/cli-tools/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "node_modules/@react-native-community/cli-tools/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "path-key": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=8"
       }
     },
     "node_modules/@react-native-community/cli-tools/node_modules/open": {
@@ -5025,12 +4849,9 @@
       }
     },
     "node_modules/@react-native-community/cli-tools/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5054,15 +4875,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-tools/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/@react-native-community/cli-types": {
-      "version": "12.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-12.3.6.tgz",
-      "integrity": "sha512-xPqTgcUtZowQ8WKOkI9TLGBwH2bGggOC4d2FFaIRST3gTcjrEeGRNeR5aXCzJFIgItIft8sd7p2oKEdy90+01Q==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-13.6.6.tgz",
+      "integrity": "sha512-733iaYzlmvNK7XYbnWlMjdE+2k0hlTBJW071af/xb6Bs+hbJqBP9c03FZuYH2hFFwDDntwj05bkri/P7VgSxug==",
       "dependencies": {
         "joi": "^17.2.1"
       }
@@ -5195,17 +5011,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@react-native-community/cli/node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -5243,12 +5048,9 @@
       }
     },
     "node_modules/@react-native-community/cli/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5267,15 +5069,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.73.1",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.73.1.tgz",
-      "integrity": "sha512-2FgAbU7uKM5SbbW9QptPPZx8N9Ke2L7bsHb+EhAanZjFZunA9PaYtyjUQ1s7HD+zDVqOQIvjkpXSv7Kejd2tqg==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.74.83.tgz",
+      "integrity": "sha512-2vkLMVnp+YTZYTNSDIBZojSsjz8sl5PscP3j4GcV6idD8V978SZfwFlk8K0ti0BzRs11mzL0Pj17km597S/eTQ==",
       "engines": {
         "node": ">=18"
       }
@@ -5284,7 +5081,6 @@
       "version": "0.74.83",
       "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.83.tgz",
       "integrity": "sha512-+S0st3t4Ro00bi9gjT1jnK8qTFOU+CwmziA7U9odKyWrCoRJrgmrvogq/Dr1YXlpFxexiGIupGut1VHxr+fxJA==",
-      "peer": true,
       "dependencies": {
         "@react-native/codegen": "0.74.83"
       },
@@ -5296,7 +5092,6 @@
       "version": "0.74.83",
       "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.74.83.tgz",
       "integrity": "sha512-KJuu3XyVh3qgyUer+rEqh9a/JoUxsDOzkJNfRpDyXiAyjDRoVch60X/Xa/NcEQ93iCVHAWs0yQ+XGNGIBCYE6g==",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
@@ -5353,7 +5148,6 @@
       "version": "0.74.83",
       "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.74.83.tgz",
       "integrity": "sha512-GgvgHS3Aa2J8/mp1uC/zU8HuTh8ZT5jz7a4mVMWPw7+rGyv70Ba8uOVBq6UH2Q08o617IATYc+0HfyzAfm4n0w==",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.0",
         "glob": "^7.1.1",
@@ -5371,20 +5165,21 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.73.17",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.73.17.tgz",
-      "integrity": "sha512-F3PXZkcHg+1ARIr6FRQCQiB7ZAA+MQXGmq051metRscoLvgYJwj7dgC8pvgy0kexzUkHu5BNKrZeySzUft3xuQ==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.74.83.tgz",
+      "integrity": "sha512-7GAFjFOg1mFSj8bnFNQS4u8u7+QtrEeflUIDVZGEfBZQ3wMNI5ycBzbBGycsZYiq00Xvoc6eKFC7kvIaqeJpUQ==",
       "dependencies": {
-        "@react-native-community/cli-server-api": "12.3.6",
-        "@react-native-community/cli-tools": "12.3.6",
-        "@react-native/dev-middleware": "0.73.8",
-        "@react-native/metro-babel-transformer": "0.73.15",
+        "@react-native-community/cli-server-api": "13.6.6",
+        "@react-native-community/cli-tools": "13.6.6",
+        "@react-native/dev-middleware": "0.74.83",
+        "@react-native/metro-babel-transformer": "0.74.83",
         "chalk": "^4.0.0",
         "execa": "^5.1.1",
         "metro": "^0.80.3",
         "metro-config": "^0.80.3",
         "metro-core": "^0.80.3",
         "node-fetch": "^2.2.0",
+        "querystring": "^0.2.1",
         "readline": "^1.3.0"
       },
       "engines": {
@@ -5511,26 +5306,28 @@
       }
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.73.3",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.73.3.tgz",
-      "integrity": "sha512-RgEKnWuoo54dh7gQhV7kvzKhXZEhpF9LlMdZolyhGxHsBqZ2gXdibfDlfcARFFifPIiaZ3lXuOVVa4ei+uPgTw==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.74.83.tgz",
+      "integrity": "sha512-RGQlVUegBRxAUF9c1ss1ssaHZh6CO+7awgtI9sDeU0PzDZY/40ImoPD5m0o0SI6nXoVzbPtcMGzU+VO590pRfA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.73.8",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.73.8.tgz",
-      "integrity": "sha512-oph4NamCIxkMfUL/fYtSsE+JbGOnrlawfQ0kKtDQ5xbOjPKotKoXqrs1eGwozNKv7FfQ393stk1by9a6DyASSg==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.74.83.tgz",
+      "integrity": "sha512-UH8iriqnf7N4Hpi20D7M2FdvSANwTVStwFCSD7VMU9agJX88Yk0D1T6Meh2RMhUu4kY2bv8sTkNRm7LmxvZqgA==",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.73.3",
+        "@react-native/debugger-frontend": "0.74.83",
+        "@rnx-kit/chromium-edge-launcher": "^1.0.0",
         "chrome-launcher": "^0.15.2",
-        "chromium-edge-launcher": "^1.0.0",
         "connect": "^3.6.5",
         "debug": "^2.2.0",
         "node-fetch": "^2.2.0",
+        "nullthrows": "^1.1.1",
         "open": "^7.0.3",
+        "selfsigned": "^2.4.1",
         "serve-static": "^1.13.1",
         "temp-dir": "^2.0.0",
         "ws": "^6.2.2"
@@ -5576,29 +5373,29 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.73.4",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.73.4.tgz",
-      "integrity": "sha512-PMDnbsZa+tD55Ug+W8CfqXiGoGneSSyrBZCMb5JfiB3AFST3Uj5e6lw8SgI/B6SKZF7lG0BhZ6YHZsRZ5MlXmg==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.74.83.tgz",
+      "integrity": "sha512-Pw2BWVyOHoBuJVKxGVYF6/GSZRf6+v1Ygc+ULGz5t20N8qzRWPa2fRZWqoxsN7TkNLPsECYY8gooOl7okOcPAQ==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.73.1",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.73.1.tgz",
-      "integrity": "sha512-ewMwGcumrilnF87H4jjrnvGZEaPFCAC4ebraEK+CurDDmwST/bIicI4hrOAv+0Z0F7DEK4O4H7r8q9vH7IbN4g==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.74.83.tgz",
+      "integrity": "sha512-/t74n8r6wFhw4JEoOj3bN71N1NDLqaawB75uKAsSjeCwIR9AfCxlzZG0etsXtOexkY9KMeZIQ7YwRPqUdNXuqw==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.73.15",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.73.15.tgz",
-      "integrity": "sha512-LlkSGaXCz+xdxc9819plmpsl4P4gZndoFtpjN3GMBIu6f7TBV0GVbyJAU4GE8fuAWPVSVL5ArOcdkWKSbI1klw==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.74.83.tgz",
+      "integrity": "sha512-hGdx5N8diu8y+GW/ED39vTZa9Jx1di2ZZ0aapbhH4egN1agIAusj5jXTccfNBwwWF93aJ5oVbRzfteZgjbutKg==",
       "dependencies": {
         "@babel/core": "^7.20.0",
-        "@react-native/babel-preset": "0.73.21",
-        "hermes-parser": "0.15.0",
+        "@react-native/babel-preset": "0.74.83",
+        "hermes-parser": "0.19.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -5607,128 +5404,16 @@
       "peerDependencies": {
         "@babel/core": "*"
       }
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.73.4",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.73.4.tgz",
-      "integrity": "sha512-XzRd8MJGo4Zc5KsphDHBYJzS1ryOHg8I2gOZDAUCGcwLFhdyGu1zBNDJYH2GFyDrInn9TzAbRIf3d4O+eltXQQ==",
-      "dependencies": {
-        "@react-native/codegen": "0.73.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-preset": {
-      "version": "0.73.21",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.73.21.tgz",
-      "integrity": "sha512-WlFttNnySKQMeujN09fRmrdWqh46QyJluM5jdtDNrkl/2Hx6N4XeDUGhABvConeK95OidVO7sFFf7sNebVXogA==",
-      "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
-        "@babel/plugin-proposal-class-properties": "^7.18.0",
-        "@babel/plugin-proposal-export-default-from": "^7.0.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.0",
-        "@babel/plugin-proposal-numeric-separator": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.20.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.20.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-        "@babel/plugin-syntax-export-default-from": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.18.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.0.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-async-to-generator": "^7.20.0",
-        "@babel/plugin-transform-block-scoping": "^7.0.0",
-        "@babel/plugin-transform-classes": "^7.0.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.20.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.20.0",
-        "@babel/plugin-transform-function-name": "^7.0.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
-        "@babel/plugin-transform-parameters": "^7.0.0",
-        "@babel/plugin-transform-private-methods": "^7.22.5",
-        "@babel/plugin-transform-private-property-in-object": "^7.22.11",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-        "@babel/plugin-transform-runtime": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.5.0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@react-native/babel-plugin-codegen": "0.73.4",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "react-refresh": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/codegen": {
-      "version": "0.73.3",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.73.3.tgz",
-      "integrity": "sha512-sxslCAAb8kM06vGy9Jyh4TtvjhcP36k/rvj2QE2Jdhdm61KvfafCATSIsOfc0QvnduWFcpXUPvAVyYwuv7PYDg==",
-      "dependencies": {
-        "@babel/parser": "^7.20.0",
-        "flow-parser": "^0.206.0",
-        "glob": "^7.1.1",
-        "invariant": "^2.2.4",
-        "jscodeshift": "^0.14.0",
-        "mkdirp": "^0.5.1",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@babel/preset-env": "^7.1.6"
-      }
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/flow-parser": {
-      "version": "0.206.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.206.0.tgz",
-      "integrity": "sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.15.0.tgz",
-      "integrity": "sha512-lLYvAd+6BnOqWdnNbP/Q8xfl8LOGw4wVjfrNd9Gt8eoFzhNBRVD95n4l2ksfMVOoxuVyegs85g83KS9QOsxbVQ=="
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.15.0.tgz",
-      "integrity": "sha512-Q1uks5rjZlE9RjMMjSUCkGrEIPI5pKJILeCtK1VmTj7U4pf3wVPoo+cxfu+s4cBAPy2JzikIIdCZgBoR6x7U1Q==",
-      "dependencies": {
-        "hermes-estree": "0.15.0"
-      }
-    },
-    "node_modules/@react-native/normalize-color": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
-      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA=="
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.73.2",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.73.2.tgz",
-      "integrity": "sha512-bRBcb2T+I88aG74LMVHaKms2p/T8aQd8+BZ7LuuzXlRfog1bMWWn/C5i0HVuvW4RPtXQYgIlGiXVDy9Ir1So/w=="
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.83.tgz",
+      "integrity": "sha512-jhCY95gRDE44qYawWVvhTjTplW1g+JtKTKM3f8xYT1dJtJ8QWv+gqEtKcfmOHfDkSDaMKG0AGBaDTSK8GXLH8Q=="
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.73.4",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.73.4.tgz",
-      "integrity": "sha512-HpmLg1FrEiDtrtAbXiwCgXFYyloK/dOIPIuWW3fsqukwJEWAiTzm1nXGJ7xPU5XTHiWZ4sKup5Ebaj8z7iyWog==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.74.83.tgz",
+      "integrity": "sha512-rmaLeE34rj7py4FxTod7iMTC7BAsm+HrGA8WxYmEJeyTV7WSaxAkosKoYBz8038mOiwnG9VwA/7FrB6bEQvn1A==",
       "dependencies": {
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1"
@@ -5737,7 +5422,14 @@
         "node": ">=18"
       },
       "peerDependencies": {
+        "@types/react": "^18.2.6",
+        "react": "*",
         "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-navigation/bottom-tabs": {
@@ -5846,46 +5538,61 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.19.3.tgz",
-      "integrity": "sha512-z5qrVL65xLXIUpU4mkR4MKlMeKARLepgHAk4W5YY3IBXOreRqOGUC70POViYmY7x38c2Ia1NwqL80H+0h7jbMw==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.9.2.tgz",
+      "integrity": "sha512-2Mt2107pfelz4T+ziDBef3P4A7kgPqCDshnEYCVGxInivJ3HHwAKUcb7MhGa8uMMMA6LMWxbAPYNHPzC3iKv2A==",
       "dependencies": {
-        "@remix-run/server-runtime": "1.19.3",
-        "@remix-run/web-fetch": "^4.3.6",
-        "@remix-run/web-file": "^3.0.3",
-        "@remix-run/web-stream": "^1.0.4",
+        "@remix-run/server-runtime": "2.9.2",
+        "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
-        "abort-controller": "^3.0.0",
         "cookie-signature": "^1.1.0",
         "source-map-support": "^0.5.21",
-        "stream-slice": "^0.1.2"
+        "stream-slice": "^0.1.2",
+        "undici": "^6.10.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz",
-      "integrity": "sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+      "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
       "engines": {
-        "node": ">=14"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.19.3.tgz",
-      "integrity": "sha512-KzQ+htUsKqpBgKE2tWo7kIIGy3MyHP58Io/itUPvV+weDjApwr9tQr9PZDPA3yAY6rAzLax7BU0NMSYCXWFY5A==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.9.2.tgz",
+      "integrity": "sha512-dX37FEeMVVg7KUbpRhX4hD0nUY0Sscz/qAjU4lYCdd6IzwJGariTmz+bQTXKCjploZuXj09OQZHSOS/ydkUVDA==",
       "dependencies": {
-        "@remix-run/router": "1.7.2",
-        "@types/cookie": "^0.4.1",
+        "@remix-run/router": "1.16.1",
+        "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
-        "cookie": "^0.4.1",
+        "cookie": "^0.6.0",
         "set-cookie-parser": "^2.4.8",
-        "source-map": "^0.7.3"
+        "source-map": "^0.7.3",
+        "turbo-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@remix-run/web-blob": {
@@ -5939,6 +5646,66 @@
         "web-streams-polyfill": "^3.1.1"
       }
     },
+    "node_modules/@rnx-kit/chromium-edge-launcher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rnx-kit/chromium-edge-launcher/-/chromium-edge-launcher-1.0.0.tgz",
+      "integrity": "sha512-lzD84av1ZQhYUS+jsGqJiCMaJO2dn9u+RTT9n9q6D3SaKVwWqv+7AoRKqBu19bkwyE+iFRl1ymr40QS90jVFYg==",
+      "dependencies": {
+        "@types/node": "^18.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.15"
+      }
+    },
+    "node_modules/@rnx-kit/chromium-edge-launcher/node_modules/@types/node": {
+      "version": "18.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.33.tgz",
+      "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@rnx-kit/chromium-edge-launcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@rnx-kit/chromium-edge-launcher/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rnx-kit/chromium-edge-launcher/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -5988,9 +5755,9 @@
       }
     },
     "node_modules/@types/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -6030,6 +5797,14 @@
       "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+      "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/prop-types": {
@@ -6957,14 +6732,9 @@
       }
     },
     "node_modules/babel-plugin-react-native-web": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.18.12.tgz",
-      "integrity": "sha512-4djr9G6fMdwQoD6LQ7hOKAm39+y12flWgovAqS1k5O8f42YQ3A1FFMyV5kKfetZuGhZO5BmNmOdRRZQ1TixtDw=="
-    },
-    "node_modules/babel-plugin-syntax-trailing-function-commas": {
-      "version": "7.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
-      "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.19.11.tgz",
+      "integrity": "sha512-0sHf8GgDhsRZxGwlwHHdfL3U8wImFaLw4haEa60U9M3EiO3bg6u3BJ+1vXhwgrevqSq76rMb5j1HJs+dNvMj5g=="
     },
     "node_modules/babel-plugin-transform-flow-enums": {
       "version": "0.0.2",
@@ -6975,158 +6745,19 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-10.0.2.tgz",
-      "integrity": "sha512-hg06qdSTK7MjKmFXSiq6cFoIbI3n3uT8a3NI2EZoISWhu+tedCj4DQduwi+3adFuRuYvAwECI0IYn/5iGh5zWQ==",
+      "version": "11.0.6",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-11.0.6.tgz",
+      "integrity": "sha512-jRi9I5/jT+dnIiNJDjDg+I/pV+AlxrIW/DNbdqYoRWPZA/LHDqD6IJnJXLxbuTcQ+llp+0LWcU7f/kC/PgGpkw==",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.12.9",
         "@babel/plugin-transform-export-namespace-from": "^7.22.11",
         "@babel/plugin-transform-object-rest-spread": "^7.12.13",
         "@babel/plugin-transform-parameters": "^7.22.15",
-        "@babel/preset-env": "^7.20.0",
         "@babel/preset-react": "^7.22.15",
-        "@react-native/babel-preset": "^0.73.18",
-        "babel-plugin-react-native-web": "~0.18.10",
-        "react-refresh": "0.14.0"
-      }
-    },
-    "node_modules/babel-preset-expo/node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.73.4",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.73.4.tgz",
-      "integrity": "sha512-XzRd8MJGo4Zc5KsphDHBYJzS1ryOHg8I2gOZDAUCGcwLFhdyGu1zBNDJYH2GFyDrInn9TzAbRIf3d4O+eltXQQ==",
-      "dependencies": {
-        "@react-native/codegen": "0.73.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/babel-preset-expo/node_modules/@react-native/babel-preset": {
-      "version": "0.73.21",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.73.21.tgz",
-      "integrity": "sha512-WlFttNnySKQMeujN09fRmrdWqh46QyJluM5jdtDNrkl/2Hx6N4XeDUGhABvConeK95OidVO7sFFf7sNebVXogA==",
-      "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
-        "@babel/plugin-proposal-class-properties": "^7.18.0",
-        "@babel/plugin-proposal-export-default-from": "^7.0.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.0",
-        "@babel/plugin-proposal-numeric-separator": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.20.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.20.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-        "@babel/plugin-syntax-export-default-from": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.18.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.0.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-async-to-generator": "^7.20.0",
-        "@babel/plugin-transform-block-scoping": "^7.0.0",
-        "@babel/plugin-transform-classes": "^7.0.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.20.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.20.0",
-        "@babel/plugin-transform-function-name": "^7.0.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
-        "@babel/plugin-transform-parameters": "^7.0.0",
-        "@babel/plugin-transform-private-methods": "^7.22.5",
-        "@babel/plugin-transform-private-property-in-object": "^7.22.11",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-        "@babel/plugin-transform-runtime": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.5.0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@react-native/babel-plugin-codegen": "0.73.4",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "react-refresh": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/babel-preset-expo/node_modules/@react-native/codegen": {
-      "version": "0.73.3",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.73.3.tgz",
-      "integrity": "sha512-sxslCAAb8kM06vGy9Jyh4TtvjhcP36k/rvj2QE2Jdhdm61KvfafCATSIsOfc0QvnduWFcpXUPvAVyYwuv7PYDg==",
-      "dependencies": {
-        "@babel/parser": "^7.20.0",
-        "flow-parser": "^0.206.0",
-        "glob": "^7.1.1",
-        "invariant": "^2.2.4",
-        "jscodeshift": "^0.14.0",
-        "mkdirp": "^0.5.1",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@babel/preset-env": "^7.1.6"
-      }
-    },
-    "node_modules/babel-preset-expo/node_modules/flow-parser": {
-      "version": "0.206.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.206.0.tgz",
-      "integrity": "sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/babel-preset-expo/node_modules/react-refresh": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
-      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-preset-fbjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
-      "integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
-      "dependencies": {
-        "@babel/plugin-proposal-class-properties": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-        "@babel/plugin-syntax-class-properties": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
-        "@babel/plugin-transform-block-scoping": "^7.0.0",
-        "@babel/plugin-transform-classes": "^7.0.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.0.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-        "@babel/plugin-transform-for-of": "^7.0.0",
-        "@babel/plugin-transform-function-name": "^7.0.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-member-expression-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-object-super": "^7.0.0",
-        "@babel/plugin-transform-parameters": "^7.0.0",
-        "@babel/plugin-transform-property-literals": "^7.0.0",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-template-literals": "^7.0.0",
-        "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/preset-typescript": "^7.23.0",
+        "@react-native/babel-preset": "~0.74.83",
+        "babel-plugin-react-native-web": "~0.19.10",
+        "react-refresh": "^0.14.2"
       }
     },
     "node_modules/balanced-match": {
@@ -7205,11 +6836,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/blueimp-md5": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
-      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w=="
     },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
@@ -7612,55 +7238,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/chromium-edge-launcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-1.0.0.tgz",
-      "integrity": "sha512-pgtgjNKZ7i5U++1g1PWv75umkHvhVTDOQIZ+sjeUX9483S7Y6MUvO0lrd7ShGlQlFHMN4SwKTCq/X8hWrbv2KA==",
-      "dependencies": {
-        "@types/node": "*",
-        "escape-string-regexp": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lighthouse-logger": "^1.0.0",
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      }
-    },
-    "node_modules/chromium-edge-launcher/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/chromium-edge-launcher/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/chromium-edge-launcher/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -7957,9 +7534,9 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -8373,19 +7950,6 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/deprecated-react-native-prop-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-5.0.0.tgz",
-      "integrity": "sha512-cIK8KYiiGVOFsKdPMmm1L3tA/Gl+JopXL6F5+C7x39MyPsQYnP57Im/D6bNUzcborD7fcMwiwZqcBdBXXZucYQ==",
-      "dependencies": {
-        "@react-native/normalize-colors": "^0.73.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/destroy": {
@@ -9404,23 +8968,23 @@
       }
     },
     "node_modules/expo": {
-      "version": "50.0.18",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-50.0.18.tgz",
-      "integrity": "sha512-es0rw+OkQNoaNQcPzv8CUpi5Qd0zipvflr6PgiXLDnv5D58R0GeAQZ7KEgYOlH+HocYrQeVm/zlpOhPPb0CEww==",
+      "version": "51.0.6",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-51.0.6.tgz",
+      "integrity": "sha512-cl3FBuSZ1gE1UcPqsMinCPmwyqedF1kug7+SK6G4vYSB8JulWmCOwjgpcOIK5lkKgNwU5sQS1nG9hPcXFB79pA==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.17.11",
-        "@expo/config": "8.5.6",
-        "@expo/config-plugins": "7.9.2",
-        "@expo/metro-config": "0.17.7",
+        "@expo/cli": "0.18.12",
+        "@expo/config": "9.0.1",
+        "@expo/config-plugins": "8.0.4",
+        "@expo/metro-config": "0.18.3",
         "@expo/vector-icons": "^14.0.0",
-        "babel-preset-expo": "~10.0.2",
-        "expo-asset": "~9.0.2",
-        "expo-file-system": "~16.0.9",
-        "expo-font": "~11.10.3",
-        "expo-keep-awake": "~12.8.2",
-        "expo-modules-autolinking": "1.10.3",
-        "expo-modules-core": "1.11.13",
+        "babel-preset-expo": "~11.0.6",
+        "expo-asset": "~10.0.6",
+        "expo-file-system": "~17.0.1",
+        "expo-font": "~12.0.5",
+        "expo-keep-awake": "~13.0.1",
+        "expo-modules-autolinking": "1.11.1",
+        "expo-modules-core": "1.12.10",
         "fbemitter": "^3.0.0",
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -9429,41 +8993,42 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-9.0.2.tgz",
-      "integrity": "sha512-PzYKME1MgUOoUvwtdzhAyXkjXOXGiSYqGKG/MsXwWr0Ef5wlBaBm2DCO9V6KYbng5tBPFu6hTjoRNil1tBOSow==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-10.0.6.tgz",
+      "integrity": "sha512-waP73/ccn/HZNNcGM4/s3X3icKjSSbEQ9mwc6tX34oYNg+XE5WdwOuZ9wgVVFrU7wZMitq22lQXd2/O0db8bxg==",
       "dependencies": {
-        "@react-native/assets-registry": "~0.73.1",
-        "blueimp-md5": "^2.10.0",
-        "expo-constants": "~15.4.0",
-        "expo-file-system": "~16.0.0",
+        "@react-native/assets-registry": "~0.74.83",
+        "expo-constants": "~16.0.0",
         "invariant": "^2.2.4",
         "md5-file": "^3.2.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-constants": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-15.4.6.tgz",
-      "integrity": "sha512-vizE69dww2Vl0PTWWvDmK0Jo2/J+WzdcMZlA05YEnEYofQuhKxTVsiuipf79mSOmFavt4UQYC1UnzptzKyfmiQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-16.0.1.tgz",
+      "integrity": "sha512-s6aTHtglp926EsugWtxN7KnpSsE9FCEjb7CgEjQQ78Gpu4btj4wB+IXot2tlqNwqv+x7xFe5veoPGfJDGF/kVg==",
       "dependencies": {
-        "@expo/config": "~8.5.0"
+        "@expo/config": "~9.0.0-beta.0"
       },
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-file-system": {
-      "version": "16.0.9",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-16.0.9.tgz",
-      "integrity": "sha512-3gRPvKVv7/Y7AdD9eHMIdfg5YbUn2zbwKofjsloTI5sEC57SLUFJtbLvUCz9Pk63DaSQ7WIE1JM0EASyvuPbuw==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-17.0.1.tgz",
+      "integrity": "sha512-dYpnZJqTGj6HCYJyXAgpFkQWsiCH3HY1ek2cFZVHFoEc5tLz9gmdEgTF6nFHurvmvfmXqxi7a5CXyVm0aFYJBw==",
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-font": {
-      "version": "11.10.3",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-11.10.3.tgz",
-      "integrity": "sha512-q1Td2zUvmLbCA9GV4OG4nLPw5gJuNY1VrPycsnemN1m8XWTzzs8nyECQQqrcBhgulCgcKZZJJ6U0kC2iuSoQHQ==",
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-12.0.5.tgz",
+      "integrity": "sha512-h/VkN4jlHYDJ6T6pPgOYTVoDEfBY0CTKQe4pxnPDGQiE6H+DFdDgk+qWVABGpRMH0+zXoHB+AEi3OoQjXIynFA==",
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -9472,19 +9037,19 @@
       }
     },
     "node_modules/expo-keep-awake": {
-      "version": "12.8.2",
-      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-12.8.2.tgz",
-      "integrity": "sha512-uiQdGbSX24Pt8nGbnmBtrKq6xL/Tm3+DuDRGBk/3ZE/HlizzNosGRIufIMJ/4B4FRw4dw8KU81h2RLuTjbay6g==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-13.0.1.tgz",
+      "integrity": "sha512-Kqv8Bf1f5Jp7YMUgTTyKR9GatgHJuAcC8vVWDEkgVhB3O7L3pgBy5MMSMUhkTmRRV6L8TZe/rDmjiBoVS/soFA==",
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-linking": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-6.2.2.tgz",
-      "integrity": "sha512-FEe6lP4f7xFT/vjoHRG+tt6EPVtkEGaWNK1smpaUevmNdyCJKqW0PDB8o8sfG6y7fly8ULe8qg3HhKh5J7aqUQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-6.3.1.tgz",
+      "integrity": "sha512-xuZCntSBGWCD/95iZ+mTUGTwHdy8Sx+immCqbUBxdvZ2TN61P02kKg7SaLS8A4a/hLrSCwrg5tMMwu5wfKr35g==",
       "dependencies": {
-        "expo-constants": "~15.4.3",
+        "expo-constants": "~16.0.0",
         "invariant": "^2.2.4"
       }
     },
@@ -9492,7 +9057,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-1.11.1.tgz",
       "integrity": "sha512-2dy3lTz76adOl7QUvbreMCrXyzUiF8lygI7iFJLjgIQIVH+43KnFWE5zBumpPbkiaq0f0uaFpN9U0RGQbnKiMw==",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "commander": "^7.2.0",
@@ -9508,7 +9072,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -9523,7 +9086,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -9539,7 +9101,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -9550,14 +9111,12 @@
     "node_modules/expo-modules-autolinking/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/expo-modules-autolinking/node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "peer": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -9572,7 +9131,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9581,7 +9139,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -9593,7 +9150,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -9605,31 +9161,30 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.11.13.tgz",
-      "integrity": "sha512-2H5qrGUvmLzmJNPDOnovH1Pfk5H/S/V0BifBmOQyDc9aUh9LaDwkqnChZGIXv8ZHDW8JRlUW0QqyWxTggkbw1A==",
+      "version": "1.12.10",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.12.10.tgz",
+      "integrity": "sha512-aS4imfr7fuUtcx+j/CHuG6ohNSThyCzGRh1kKjQTDcO0/CqDO2cSFnxf7n2vpiRFgyoMFJvFFtW/zIzVXiC2Tw==",
       "dependencies": {
         "invariant": "^2.2.4"
       }
     },
     "node_modules/expo-router": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-3.4.10.tgz",
-      "integrity": "sha512-3Ldhsva/EtfWFFTDaTl6PRuJFJWG0DTd3OOI3U9/tY+/S7oaNbIOO8yVJbbTbsymAreVZuDwrQsfCmw0xLsB7g==",
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-3.5.14.tgz",
+      "integrity": "sha512-RVsyJLosZSq89ebA5qfPToRcFZJoTTb+6nwPHk6iESD6KON/Q7ZODt5fvCwXkY86tLNEMGo160QvBPfBZmglaA==",
       "dependencies": {
-        "@expo/metro-runtime": "3.1.3",
-        "@expo/server": "^0.3.0",
+        "@expo/metro-runtime": "3.2.1",
+        "@expo/server": "^0.4.0",
         "@radix-ui/react-slot": "1.0.1",
         "@react-navigation/bottom-tabs": "~6.5.7",
         "@react-navigation/native": "~6.1.6",
         "@react-navigation/native-stack": "~6.9.12",
-        "expo-splash-screen": "~0.26.5",
+        "expo-splash-screen": "0.27.4",
         "react-native-helmet-async": "2.0.4",
         "schema-utils": "^4.0.1"
       },
@@ -9656,133 +9211,20 @@
       }
     },
     "node_modules/expo-splash-screen": {
-      "version": "0.26.5",
-      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.26.5.tgz",
-      "integrity": "sha512-FyvA2EWDeQdC3zuoQdXV2VmSANiJzF0hmbtoEEyR6MXoHaYFvxxKyhBeAm61N8C9TtUijIcEgFM6XBCh0wTBVw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.27.4.tgz",
+      "integrity": "sha512-JwepK1FjbwiOK2nwIFanfzj9s7UXYnpTwLX8A9v7Ec3K4V28yu8HooSc9X60cftBw9UZrs8Gwj4PgTpQabBS9A==",
       "dependencies": {
-        "@expo/prebuild-config": "6.8.1"
+        "@expo/prebuild-config": "7.0.3"
       },
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.11.1.tgz",
-      "integrity": "sha512-ddQEtCOgYHTLlFUe/yH67dDBIoct5VIULthyT3LRJbEwdpzAgueKsX2FYK02ldh440V87PWKCamh7R9evk1rrg=="
-    },
-    "node_modules/expo/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/expo/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/expo/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/expo/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/expo/node_modules/expo-modules-autolinking": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-1.10.3.tgz",
-      "integrity": "sha512-pn4n2Dl4iRh/zUeiChjRIe1C7EqOw1qhccr85viQV7W6l5vgRpY0osE51ij5LKg/kJmGRcJfs12+PwbdTplbKw==",
-      "dependencies": {
-        "@expo/config": "~8.5.0",
-        "chalk": "^4.1.0",
-        "commander": "^7.2.0",
-        "fast-glob": "^3.2.5",
-        "find-up": "^5.0.0",
-        "fs-extra": "^9.1.0"
-      },
-      "bin": {
-        "expo-modules-autolinking": "bin/expo-modules-autolinking.js"
-      }
-    },
-    "node_modules/expo/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/expo/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/expo/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/expo/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.12.1.tgz",
+      "integrity": "sha512-/t3xdbS8KB0prj5KG5w7z+wZPFlPtkgs95BsmrP/E7Q0xHXTcDcQ6Cu2FkFuRM+PKTb17cJDnLkawyS5vDLxMA=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -10456,14 +9898,12 @@
     "node_modules/hermes-estree": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.19.1.tgz",
-      "integrity": "sha512-daLGV3Q2MKk8w4evNMKwS8zBE/rcpA800nu1Q5kM08IKijoSnPe9Uo1iIxzPKRkn95IxxsgBMPeYHt3VG4ej2g==",
-      "peer": true
+      "integrity": "sha512-daLGV3Q2MKk8w4evNMKwS8zBE/rcpA800nu1Q5kM08IKijoSnPe9Uo1iIxzPKRkn95IxxsgBMPeYHt3VG4ej2g=="
     },
     "node_modules/hermes-parser": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.19.1.tgz",
       "integrity": "sha512-Vp+bXzxYJWrpEuJ/vXxUsLnt0+y4q9zyi4zUlkLqD8FKv4LjIfOvP69R/9Lty3dCyKh0E2BU7Eypqr63/rKT/A==",
-      "peer": true,
       "dependencies": {
         "hermes-estree": "0.19.1"
       }
@@ -14797,6 +14237,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/queue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
@@ -14866,9 +14315,9 @@
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "4.28.5",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.28.5.tgz",
-      "integrity": "sha512-cq/o30z9W2Wb4rzBefjv5fBalHU0rJGZCHAkf/RHSBWSSYwh8PlQTqqOJmgIIbBtpj27T6FIPXeomIjZtCNVqA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-5.2.0.tgz",
+      "integrity": "sha512-vZK+/gvxxsieAoAyYaiRIVFxlajb7KXhgBDV7OsoMzaAE+IqGpoxusBjIgq5ibqA2IloKu0p9n7tE68z1xs18A==",
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -14928,27 +14377,26 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-native": {
-      "version": "0.73.6",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.73.6.tgz",
-      "integrity": "sha512-oqmZe8D2/VolIzSPZw+oUd6j/bEmeRHwsLn1xLA5wllEYsZ5zNuMsDus235ONOnCRwexqof/J3aztyQswSmiaA==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.74.1.tgz",
+      "integrity": "sha512-0H2XpmghwOtfPpM2LKqHIN7gxy+7G/r1hwJHKLV6uoyXGC/gCojRtoo5NqyKrWpFC8cqyT6wTYCLuG7CxEKilg==",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
-        "@react-native-community/cli": "12.3.6",
-        "@react-native-community/cli-platform-android": "12.3.6",
-        "@react-native-community/cli-platform-ios": "12.3.6",
-        "@react-native/assets-registry": "0.73.1",
-        "@react-native/codegen": "0.73.3",
-        "@react-native/community-cli-plugin": "0.73.17",
-        "@react-native/gradle-plugin": "0.73.4",
-        "@react-native/js-polyfills": "0.73.1",
-        "@react-native/normalize-colors": "0.73.2",
-        "@react-native/virtualized-lists": "0.73.4",
+        "@react-native-community/cli": "13.6.6",
+        "@react-native-community/cli-platform-android": "13.6.6",
+        "@react-native-community/cli-platform-ios": "13.6.6",
+        "@react-native/assets-registry": "0.74.83",
+        "@react-native/codegen": "0.74.83",
+        "@react-native/community-cli-plugin": "0.74.83",
+        "@react-native/gradle-plugin": "0.74.83",
+        "@react-native/js-polyfills": "0.74.83",
+        "@react-native/normalize-colors": "0.74.83",
+        "@react-native/virtualized-lists": "0.74.83",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
         "base64-js": "^1.5.1",
         "chalk": "^4.0.0",
-        "deprecated-react-native-prop-types": "^5.0.0",
         "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
@@ -14961,7 +14409,7 @@
         "nullthrows": "^1.1.1",
         "pretty-format": "^26.5.2",
         "promise": "^8.3.0",
-        "react-devtools-core": "^4.27.7",
+        "react-devtools-core": "^5.0.0",
         "react-refresh": "^0.14.0",
         "react-shallow-renderer": "^16.15.0",
         "regenerator-runtime": "^0.13.2",
@@ -14978,7 +14426,13 @@
         "node": ">=18"
       },
       "peerDependencies": {
+        "@types/react": "^18.2.6",
         "react": "18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-dotenv": {
@@ -15006,18 +14460,18 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.8.2.tgz",
-      "integrity": "sha512-ffUOv8BJQ6RqO3nLml5gxJ6ab3EestPiyWekxdzO/1MQ7NF8fW1Mzh1C5QE9yq573Xefnc7FuzGXjtesZGv7cQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.10.1.tgz",
+      "integrity": "sha512-w8tCuowDorUkPoWPXmhqosovBr33YsukkwYCDERZFHAxIkx6qBadYxfeoaJ91nCQKjkNzGrK5qhoNOeSIcYSpA==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
       }
     },
     "node_modules/react-native-screens": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.29.0.tgz",
-      "integrity": "sha512-yB1GoAMamFAcYf4ku94uBPn0/ani9QG7NdI98beJ5cet2YFESYYzuEIuU+kt+CNRcO8qqKeugxlfgAa3HyTqlg==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.31.1.tgz",
+      "integrity": "sha512-8fRW362pfZ9y4rS8KY5P3DFScrmwo/vu1RrRMMx0PNHbeC9TLq0Kw1ubD83591yz64gLNHFLTVkTJmWeWCXKtQ==",
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -15046,35 +14500,10 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/react-native-web/node_modules/@react-native/normalize-colors": {
-      "version": "0.74.83",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.83.tgz",
-      "integrity": "sha512-jhCY95gRDE44qYawWVvhTjTplW1g+JtKTKM3f8xYT1dJtJ8QWv+gqEtKcfmOHfDkSDaMKG0AGBaDTSK8GXLH8Q=="
-    },
     "node_modules/react-native-web/node_modules/memoize-one": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
-    },
-    "node_modules/react-native/node_modules/@react-native/codegen": {
-      "version": "0.73.3",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.73.3.tgz",
-      "integrity": "sha512-sxslCAAb8kM06vGy9Jyh4TtvjhcP36k/rvj2QE2Jdhdm61KvfafCATSIsOfc0QvnduWFcpXUPvAVyYwuv7PYDg==",
-      "dependencies": {
-        "@babel/parser": "^7.20.0",
-        "flow-parser": "^0.206.0",
-        "glob": "^7.1.1",
-        "invariant": "^2.2.4",
-        "jscodeshift": "^0.14.0",
-        "mkdirp": "^0.5.1",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@babel/preset-env": "^7.1.6"
-      }
     },
     "node_modules/react-native/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -15120,14 +14549,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/react-native/node_modules/flow-parser": {
-      "version": "0.206.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.206.0.tgz",
-      "integrity": "sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/react-native/node_modules/has-flag": {
       "version": "4.0.0",
@@ -15327,6 +14748,7 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
       "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.8.4"
       }
@@ -15643,6 +15065,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -16781,6 +16215,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
+    "node_modules/turbo-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.0.1.tgz",
+      "integrity": "sha512-sm0ZtcX9YWh28p5X8t5McxC2uthrt9p+g0bGE0KTVFhnhNWefpSVCr+67zRNDUOfo4bpXwiOp7otO+dyQ7/y/A=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -16898,10 +16337,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16944,6 +16383,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.16.1.tgz",
+      "integrity": "sha512-NeNiTT7ixpeiL1qOIU/xTVpHpVP0svmI6PwoCKaMGaI5AsHOaRdwqU/f7Fi9eyU4u03nd5U/BC8wmRMnS9nqoA==",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -13,20 +13,20 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@expo/metro-runtime": "~3.1.3",
-    "expo": "^50.0.18",
-    "expo-constants": "~15.4.6",
-    "expo-font": "^11.10.3",
-    "expo-linking": "~6.2.2",
-    "expo-router": "~3.4.10",
-    "expo-status-bar": "~1.11.1",
+    "@expo/metro-runtime": "~3.2.1",
+    "expo": "~51.0.6",
+    "expo-constants": "~16.0.1",
+    "expo-font": "~12.0.5",
+    "expo-linking": "~6.3.1",
+    "expo-router": "~3.5.14",
+    "expo-status-bar": "~1.12.1",
     "nativewind": "^2.0.11",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native": "0.73.6",
+    "react-native": "0.74.1",
     "react-native-dotenv": "^3.4.11",
-    "react-native-safe-area-context": "4.8.2",
-    "react-native-screens": "~3.29.0",
+    "react-native-safe-area-context": "4.10.1",
+    "react-native-screens": "3.31.1",
     "react-native-web": "~0.19.6",
     "zustand": "^4.5.2"
   },
@@ -41,7 +41,7 @@
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",
     "tailwindcss": "3.3.2",
-    "typescript": "^5.1.3"
+    "typescript": "~5.3.3"
   },
   "private": true,
   "lint-staged": {


### PR DESCRIPTION
- Bumps Expo SDK to version 51 (released[ last week](https://expo.dev/changelog/2024/05-07-sdk-51)) and fixes dependency issues the bump has caused
- Makes the project run on Expo Go client app as it requires version 51
- Fixed with `npx expo install --fix` after installing sdk 51

# Screenshot
![image](https://github.com/0-BSCode/pokedex-mobile/assets/64140516/3740a3ec-54d4-4311-8cdb-6a28203629f0)
