### PR TITLE
[CD] Change Flying Type Icon

### DIFF
--- a/src/components/TypeIcon/index.tsx
+++ b/src/components/TypeIcon/index.tsx
@@ -71,7 +71,7 @@ export default function TypeIcon({ type }: Props) {
         case PokemonTypesEnum.FLYING:
             return (
                 <FontAwesome5
-                    name="wind"
+                    name="feather"
                     size={20}
                     color={determineTypeColor(type)}
                 />


### PR DESCRIPTION
## Describe your changes
- quick visual change to make the flying type icon a feather instead of wind.

## Screenshots/Images
![image](https://github.com/0-BSCode/pokedex-mobile/assets/105530193/842d6bbe-a6d8-4a2c-813e-1f49cbb346ce)